### PR TITLE
COMPONENTS: New SharpStyle and Convert Extensions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,26 @@
+name: Build & Test SharpStyles
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+jobs:
+  build:
+    name: Build
+    runs-on: windows-2022
+    steps:
+    - name: Check Out
+      uses: actions/checkout@v2
+    - name: Setup Dot Net Version
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 9.0.101
+        include-prerelease: true
+    - name: Restore
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore
+    - name: Test
+      run: dotnet test --no-build --verbosity normal

--- a/SharpStyles.Infrastructure.Build/Program.cs
+++ b/SharpStyles.Infrastructure.Build/Program.cs
@@ -1,0 +1,45 @@
+﻿// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib
+// Licensed under the MIT License.
+// See License.txt in the project root for license information.
+// ---------------------------------------------------------------
+
+using System.IO;
+using ADotNet.Clients.Builders;
+using ADotNet.Models.Pipelines.GithubPipelines.DotNets;
+
+namespace SharpStyles.Infrastructure.Build
+{
+    internal class Program
+    {
+        static void Main(string[] args)
+        {
+            string buildScriptPath = "../../../../.github/workflows/dotnet.yml";
+            string directoryPath = Path.GetDirectoryName(buildScriptPath);
+
+            if (Directory.Exists(directoryPath) is false)
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            GitHubPipelineBuilder.CreateNewPipeline()
+                .SetName("Build & Test SharpStyles")
+                    .OnPush("master")
+                        .OnPullRequest("master")
+                            .AddJob("build", job => job
+                                .WithName("Build")
+                                .RunsOn(BuildMachines.Windows2022)
+                                .AddCheckoutStep("Check Out")
+
+                                .AddSetupDotNetStep(
+                                    version: "9.0.101",
+                                    includePrerelease: true)
+
+                                .AddRestoreStep()
+                                .AddBuildStep()
+                                .AddTestStep())
+
+                .SaveToFile(buildScriptPath);
+        }
+    }
+}

--- a/SharpStyles.Infrastructure.Build/SharpStyles.Infrastructure.Build.csproj
+++ b/SharpStyles.Infrastructure.Build/SharpStyles.Infrastructure.Build.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ADotNet" Version="4.1.0" />
+  </ItemGroup>
+
+</Project>

--- a/SharpStyles.Tests.Unit/Models/SharpStyleTests.cs
+++ b/SharpStyles.Tests.Unit/Models/SharpStyleTests.cs
@@ -7,6 +7,7 @@
 using FluentAssertions;
 using SharpStyles.Models;
 using SharpStyles.Models.Attributes;
+using SharpStyles.Models.Queries;
 using Tynamix.ObjectFiller;
 using Xunit;
 

--- a/SharpStyles.Tests.Unit/Services/Styles/StyleServiceTests.Logic.cs
+++ b/SharpStyles.Tests.Unit/Services/Styles/StyleServiceTests.Logic.cs
@@ -1,0 +1,74 @@
+﻿// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib
+// Licensed under the MIT License.
+// See License.txt in the project root for license information.
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using SharpStyles.Models;
+using SharpStyles.Services.Styles;
+using Xunit;
+
+namespace SharpStyles.Tests.Unit.Services.Styles
+{
+    public partial class StyleServiceTests
+    {
+        [Fact]
+        public void ShouldSerializeSharpStyleToCssRules()
+        {
+            // given
+            string randomValue = GetRandomString();
+
+            var testStyle = new TestStyle
+            {
+                MyElement = new SharpStyle
+                {
+                    BackgroundColor = randomValue
+                },
+
+                MyId = new SharpStyle
+                {
+                    BackgroundColor = randomValue
+                },
+
+                MyClass = new SharpStyle
+                {
+                    BackgroundColor = randomValue
+                },
+
+                MyDeep = new SharpStyle
+                {
+                    BackgroundColor = randomValue
+                }
+            };
+
+            string expectedStyle = @$"
+
+my-element {{
+	background-color: {randomValue};
+}}
+
+#my-id {{
+	background-color: {randomValue};
+}}
+
+.my-class {{
+	background-color: {randomValue};
+}}
+
+::deep my-deep {{
+	background-color: {randomValue};
+}}
+";
+
+            // when
+            IStyleService styleService = new StyleService();
+
+            string actualStyle = styleService.ToCss(
+                sharpStyle: testStyle);
+
+            // then
+            actualStyle.Should().BeEquivalentTo(expectedStyle);
+        }
+    }
+}

--- a/SharpStyles.Tests.Unit/Services/Styles/StyleServiceTests.Logic.cs
+++ b/SharpStyles.Tests.Unit/Services/Styles/StyleServiceTests.Logic.cs
@@ -67,7 +67,7 @@ my-element {{
             // when
             IStyleService styleService = new StyleService();
 
-            string actualStyle = styleService.ToCss(
+            string actualStyle = styleService.ToStyleCss(
                 sharpStyle: testStyle);
 
             // then
@@ -180,7 +180,7 @@ my-element {{
             // when
             IStyleService styleService = new StyleService();
 
-            string actualStyle = styleService.ToCss(
+            string actualStyle = styleService.ToStyleCss(
                 sharpStyle: testStyle);
 
             // then
@@ -288,7 +288,7 @@ my-element {{
             // when
             IStyleService styleService = new StyleService();
 
-            string actualStyle = styleService.ToCss(
+            string actualStyle = styleService.ToStyleCss(
                 sharpStyle: testStyle);
 
             // then

--- a/SharpStyles.Tests.Unit/Services/Styles/StyleServiceTests.Logic.cs
+++ b/SharpStyles.Tests.Unit/Services/Styles/StyleServiceTests.Logic.cs
@@ -99,7 +99,7 @@ my-element {{
 
                 MyDeep = new SharpStyle
                 {
-                    BackgroundColor = randomValue
+                    BackgroundColor = randomSmallDeviceValue
                 }
             };
 
@@ -153,7 +153,8 @@ my-element {{
 	background-color: {randomValue};
 }}
 
-@media (min-width: 768px) {{
+@media (max-width: 768px) {{
+
 
 my-element {{
 	background-color: {randomSmallDeviceValue};
@@ -172,6 +173,7 @@ my-element {{
 }}
 
 }}
+
 ";
 
             // when

--- a/SharpStyles.Tests.Unit/Services/Styles/StyleServiceTests.Logic.cs
+++ b/SharpStyles.Tests.Unit/Services/Styles/StyleServiceTests.Logic.cs
@@ -7,6 +7,7 @@
 using System.Collections.Generic;
 using FluentAssertions;
 using SharpStyles.Models;
+using SharpStyles.Models.Keyframes;
 using SharpStyles.Models.Queries;
 using SharpStyles.Services.Styles;
 using Xunit;
@@ -172,6 +173,114 @@ my-element {{
 	background-color: {randomSmallDeviceValue};
 }}
 
+}}
+
+";
+
+            // when
+            IStyleService styleService = new StyleService();
+
+            string actualStyle = styleService.ToCss(
+                sharpStyle: testStyle);
+
+            // then
+            actualStyle.Should().BeEquivalentTo(expectedStyle);
+        }
+
+        [Fact]
+        public void ShouldSerializeSharpStyleWithKeyFramesToCssRules()
+        {
+            // given
+            string randomValue = GetRandomString();
+            string randomSmallDeviceValue = GetRandomString();
+
+            var keyframes = new SharpKeyframes
+            {
+                Name = "fadeIn",
+
+                Keyframes = new List<SharpKeyframe>
+                {
+                    new SharpKeyframe()
+                    {
+                        Selector = "from",
+                        Properties = new List<SharpKeyframeProperty>()
+                        {
+                            new SharpKeyframeProperty()
+                            {
+                                Name = "opacity",
+                                Value = "0"
+                            }
+                        }
+                    },
+
+                    new SharpKeyframe()
+                    {
+                        Selector = "to",
+                        Properties = new()
+                        {
+                            new SharpKeyframeProperty()
+                            {
+                                Name = "opacity",
+                                Value = randomValue
+                            }
+                        }
+                    }
+                }
+            };
+
+            var testStyle = new TestStyle
+            {
+                MyElement = new SharpStyle
+                {
+                    BackgroundColor = randomValue
+                },
+
+                MyId = new SharpStyle
+                {
+                    BackgroundColor = randomValue
+                },
+
+                MyClass = new SharpStyle
+                {
+                    BackgroundColor = randomValue
+                },
+
+                MyDeep = new SharpStyle
+                {
+                    BackgroundColor = randomValue
+                },
+
+                Keyframes = new List<SharpKeyframes>
+                {
+                    keyframes
+                }
+            };
+
+            string expectedStyle = @$"
+
+my-element {{
+	background-color: {randomValue};
+}}
+
+#my-id {{
+	background-color: {randomValue};
+}}
+
+.my-class {{
+	background-color: {randomValue};
+}}
+
+::deep my-deep {{
+	background-color: {randomValue};
+}}
+
+@keyframes fadeIn {{
+  from {{
+    opacity: 0;
+  }}
+  to {{
+    opacity: {randomValue};
+  }}
 }}
 
 ";

--- a/SharpStyles.Tests.Unit/Services/Styles/StyleServiceTests.Logic.cs
+++ b/SharpStyles.Tests.Unit/Services/Styles/StyleServiceTests.Logic.cs
@@ -4,8 +4,10 @@
 // See License.txt in the project root for license information.
 // ---------------------------------------------------------------
 
+using System.Collections.Generic;
 using FluentAssertions;
 using SharpStyles.Models;
+using SharpStyles.Models.Queries;
 using SharpStyles.Services.Styles;
 using Xunit;
 
@@ -58,6 +60,117 @@ my-element {{
 
 ::deep my-deep {{
 	background-color: {randomValue};
+}}
+";
+
+            // when
+            IStyleService styleService = new StyleService();
+
+            string actualStyle = styleService.ToCss(
+                sharpStyle: testStyle);
+
+            // then
+            actualStyle.Should().BeEquivalentTo(expectedStyle);
+        }
+
+        [Fact]
+        public void ShouldSerializeSharpStyleWithMediaQueriesToCssRules()
+        {
+            // given
+            string randomValue = GetRandomString();
+            string randomSmallDeviceValue = GetRandomString();
+
+            var smallScreenStyle = new TestStyle
+            {
+                MyElement = new SharpStyle
+                {
+                    BackgroundColor = randomSmallDeviceValue
+                },
+
+                MyId = new SharpStyle
+                {
+                    BackgroundColor = randomSmallDeviceValue
+                },
+
+                MyClass = new SharpStyle
+                {
+                    BackgroundColor = randomSmallDeviceValue
+                },
+
+                MyDeep = new SharpStyle
+                {
+                    BackgroundColor = randomValue
+                }
+            };
+
+            var testStyle = new TestStyle
+            {
+                MyElement = new SharpStyle
+                {
+                    BackgroundColor = randomValue
+                },
+
+                MyId = new SharpStyle
+                {
+                    BackgroundColor = randomValue
+                },
+
+                MyClass = new SharpStyle
+                {
+                    BackgroundColor = randomValue
+                },
+
+                MyDeep = new SharpStyle
+                {
+                    BackgroundColor = randomValue
+                },
+
+                MediaQueries = new List<MediaQuery>
+                {
+                    new MediaQuery
+                    {
+                        MaxWidth  = 768,
+                        Styles = smallScreenStyle
+                    }
+                }
+            };
+
+            string expectedStyle = @$"
+
+my-element {{
+	background-color: {randomValue};
+}}
+
+#my-id {{
+	background-color: {randomValue};
+}}
+
+.my-class {{
+	background-color: {randomValue};
+}}
+
+::deep my-deep {{
+	background-color: {randomValue};
+}}
+
+@media (min-width: 768px) {{
+
+my-element {{
+	background-color: {randomSmallDeviceValue};
+}}
+
+#my-id {{
+	background-color: {randomSmallDeviceValue};
+}}
+
+.my-class {{
+	background-color: {randomSmallDeviceValue};
+}}
+
+::deep my-deep {{
+	background-color: {randomSmallDeviceValue};
+}}
+
 }}
 ";
 

--- a/SharpStyles.Tests.Unit/Services/Styles/StyleServiceTests.cs
+++ b/SharpStyles.Tests.Unit/Services/Styles/StyleServiceTests.cs
@@ -1,0 +1,33 @@
+﻿// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib
+// Licensed under the MIT License.
+// See License.txt in the project root for license information.
+// ---------------------------------------------------------------
+
+using SharpStyles.Models;
+using SharpStyles.Models.Attributes;
+using Tynamix.ObjectFiller;
+
+namespace SharpStyles.Tests.Unit.Services.Styles
+{
+    public partial class StyleServiceTests
+    {
+        internal class TestStyle : SharpStyle
+        {
+            [CssElement]
+            public SharpStyle MyElement { get; set; }
+
+            [CssId]
+            public SharpStyle MyId { get; set; }
+
+            [CssClass]
+            public SharpStyle MyClass { get; set; }
+
+            [CssDeep]
+            public SharpStyle MyDeep { get; set; }
+        }
+
+        private static string GetRandomString() =>
+            new MnemonicString().GetValue();
+    }
+}

--- a/SharpStyles.Tests.Unit/SharpStyles.Tests.Unit.csproj
+++ b/SharpStyles.Tests.Unit/SharpStyles.Tests.Unit.csproj
@@ -1,22 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Tynamix.ObjectFiller" Version="1.5.8" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="FluentAssertions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageReference Include="Tynamix.ObjectFiller" Version="1.5.9" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/SharpStyles.sln
+++ b/SharpStyles.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharpStyles", "SharpStyles\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharpStyles.Tests.Unit", "SharpStyles.Tests.Unit\SharpStyles.Tests.Unit.csproj", "{D19B362E-2180-4027-A4A2-CEDC5926462F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharpStyles.Infrastructure.Build", "SharpStyles.Infrastructure.Build\SharpStyles.Infrastructure.Build.csproj", "{FF9FCE9E-8096-4F71-ADF1-74D535C7F88F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{D19B362E-2180-4027-A4A2-CEDC5926462F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D19B362E-2180-4027-A4A2-CEDC5926462F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D19B362E-2180-4027-A4A2-CEDC5926462F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FF9FCE9E-8096-4F71-ADF1-74D535C7F88F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FF9FCE9E-8096-4F71-ADF1-74D535C7F88F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FF9FCE9E-8096-4F71-ADF1-74D535C7F88F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FF9FCE9E-8096-4F71-ADF1-74D535C7F88F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SharpStyles/Extensions/SharpStylesExtensions.cs
+++ b/SharpStyles/Extensions/SharpStylesExtensions.cs
@@ -1,0 +1,47 @@
+﻿// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib
+// Licensed under the MIT License.
+// See License.txt in the project root for license information.
+// ---------------------------------------------------------------
+
+using SharpStyles.Models;
+using SharpStyles.Models.Keyframes;
+using SharpStyles.Models.Queries;
+using SharpStyles.Services.Styles;
+
+namespace SharpStyles.Extensions
+{
+    /// <summary>
+    /// Provides extension methods for working with <see cref="SharpStyle"/> instances,
+    /// including conversion to CSS style strings.
+    /// </summary>
+    public static class SharpStylesExtensions
+    {
+        /// <summary>
+        /// Converts the specified <see cref="SharpStyle"/> instance to a CSS style string.
+        /// </summary>
+        public static string ToStyleCss(this SharpStyle sharpStyle)
+        {
+            IStyleService styleService = new StyleService();
+            return styleService.ToStyleCss(sharpStyle);
+        }
+
+        /// <summary>
+        /// Converts the specified <see cref="MediaQuery"/> instance to a media query CSS style string.
+        /// </summary>
+        public static string ToQueryCss(this MediaQuery mediaQuery)
+        {
+            IStyleService styleService = new StyleService();
+            return styleService.ToQueryCss(mediaQuery);
+        }
+
+        /// <summary>
+        /// Converts the specified <see cref="SharpKeyframes"/> instance to a keyframes CSS style string.
+        /// </summary>
+        public static string ToKeyframesCss(this SharpKeyframes keyframes)
+        {
+            IStyleService styleService = new StyleService();
+            return styleService.ToKeyframesCss(keyframes);
+        }
+    }
+}

--- a/SharpStyles/Models/Keyframes/SharpKeyframes.cs
+++ b/SharpStyles/Models/Keyframes/SharpKeyframes.cs
@@ -4,6 +4,7 @@
 // See License.txt in the project root for license information.
 // ---------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -15,6 +16,8 @@ namespace SharpStyles.Models.Keyframes
 
         public List<SharpKeyframe> Keyframes { get; set; }
 
+        [Obsolete("ToCss is obsolete and only supports legacy nested style serialization." +
+           " Use ToKeyframesCss() extension method instead.")]
         public string ToCss()
         {
             if (string.IsNullOrEmpty(Name)

--- a/SharpStyles/Models/Queries/MediaQuery.cs
+++ b/SharpStyles/Models/Queries/MediaQuery.cs
@@ -7,7 +7,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace SharpStyles.Models
+namespace SharpStyles.Models.Queries
 {
     public class MediaQuery
     {

--- a/SharpStyles/Models/Queries/MediaQuery.cs
+++ b/SharpStyles/Models/Queries/MediaQuery.cs
@@ -4,6 +4,7 @@
 // See License.txt in the project root for license information.
 // ---------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -46,6 +47,8 @@ namespace SharpStyles.Models.Queries
         /// </summary>
         public SharpStyle Styles { get; set; }
 
+        [Obsolete("ToCss is obsolete and only supports legacy nested style serialization." +
+           " Use ToQueryCss() extension method instead.")]
         public string ToCss()
         {
             var sb = new StringBuilder();

--- a/SharpStyles/Models/SharpStyle.cs
+++ b/SharpStyles/Models/SharpStyle.cs
@@ -4,11 +4,15 @@
 // See License.txt in the project root for license information.
 // ---------------------------------------------------------------
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 using SharpStyles.Models.Attributes;
+using SharpStyles.Models.Keyframes;
+using SharpStyles.Models.Queries;
 
 namespace SharpStyles.Models
 {
@@ -869,6 +873,19 @@ namespace SharpStyles.Models
         /// </summary>
         public string PointerEvents { get; set; }
 
+        /// <summary>
+        /// Specifies a collection of keyframe animations associated with this style.
+        /// Each <see cref="SharpKeyframes"/> defines a named set of keyframes for use in CSS animations.
+        /// </summary>
+        public List<SharpKeyframes> Keyframes { get; set; }
+
+        /// <summary>
+        /// Specifies a collection of media queries that apply conditional styles based 
+        /// on device characteristics such as screen size, orientation, or other media features.
+        /// </summary>
+        public List<MediaQuery> MediaQueries { get; set; }
+
+        [Obsolete("ToCss is obsolete and only supports legacy nested style serialization. Use the new CSS generation APIs instead.")]
         public string ToCss()
         {
             var reg = new Regex("([a-z,0-9](?=[A-Z])|[A-Z](?=[A-Z][a-z]))");

--- a/SharpStyles/Models/SharpStyle.cs
+++ b/SharpStyles/Models/SharpStyle.cs
@@ -885,7 +885,8 @@ namespace SharpStyles.Models
         /// </summary>
         public List<MediaQuery> MediaQueries { get; set; }
 
-        [Obsolete("ToCss is obsolete and only supports legacy nested style serialization. Use the new CSS generation APIs instead.")]
+        [Obsolete("ToCss is obsolete and only supports legacy nested style serialization." +
+            " Use ToStyleCss() extension method instead.")]
         public string ToCss()
         {
             var reg = new Regex("([a-z,0-9](?=[A-Z])|[A-Z](?=[A-Z][a-z]))");

--- a/SharpStyles/Services/Styles/IStyleService.cs
+++ b/SharpStyles/Services/Styles/IStyleService.cs
@@ -5,13 +5,15 @@
 // ---------------------------------------------------------------
 
 using SharpStyles.Models;
+using SharpStyles.Models.Keyframes;
 using SharpStyles.Models.Queries;
 
 namespace SharpStyles.Services.Styles
 {
     internal interface IStyleService
     {
-        string ToCss(SharpStyle sharpStyle);
+        string ToStyleCss(SharpStyle sharpStyle);
         string ToQueryCss(MediaQuery mediaQuery);
+        string ToKeyframesCss(SharpKeyframes sharpKeyframes);
     }
 }

--- a/SharpStyles/Services/Styles/IStyleService.cs
+++ b/SharpStyles/Services/Styles/IStyleService.cs
@@ -5,11 +5,13 @@
 // ---------------------------------------------------------------
 
 using SharpStyles.Models;
+using SharpStyles.Models.Queries;
 
 namespace SharpStyles.Services.Styles
 {
     internal interface IStyleService
     {
         string ToCss(SharpStyle sharpStyle);
+        string ToQueryCss(MediaQuery mediaQuery);
     }
 }

--- a/SharpStyles/Services/Styles/IStyleService.cs
+++ b/SharpStyles/Services/Styles/IStyleService.cs
@@ -1,0 +1,15 @@
+﻿// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib
+// Licensed under the MIT License.
+// See License.txt in the project root for license information.
+// ---------------------------------------------------------------
+
+using SharpStyles.Models;
+
+namespace SharpStyles.Services.Styles
+{
+    internal interface IStyleService
+    {
+        string ToCss(SharpStyle sharpStyle);
+    }
+}

--- a/SharpStyles/Services/Styles/StyleService.Keyframes.cs
+++ b/SharpStyles/Services/Styles/StyleService.Keyframes.cs
@@ -1,0 +1,41 @@
+﻿// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib
+// Licensed under the MIT License.
+// See License.txt in the project root for license information.
+// ---------------------------------------------------------------
+
+using System.Text;
+using SharpStyles.Models.Keyframes;
+
+namespace SharpStyles.Services.Styles
+{
+    internal partial class StyleService : IStyleService
+    {
+        public string ToKeyframesCss(SharpKeyframes sharpKeyframes)
+        {
+            if (string.IsNullOrEmpty(sharpKeyframes?.Name)
+                || sharpKeyframes?.Keyframes is null
+                    || sharpKeyframes?.Keyframes.Count is 0)
+            {
+                return string.Empty;
+            }
+
+            var stringBuilder = new StringBuilder();
+            stringBuilder.AppendLine();
+            stringBuilder.AppendLine($"@keyframes {sharpKeyframes.Name} {{");
+
+            foreach (var keyframe in sharpKeyframes.Keyframes)
+            {
+                stringBuilder.AppendLine($"  {keyframe.Selector} {{");
+                foreach (var prop in keyframe.Properties)
+                {
+                    stringBuilder.AppendLine($"    {prop.Name}: {prop.Value};");
+                }
+                stringBuilder.AppendLine("  }");
+            }
+
+            stringBuilder.AppendLine("}");
+            return stringBuilder.ToString();
+        }
+    }
+}

--- a/SharpStyles/Services/Styles/StyleService.Queries.cs
+++ b/SharpStyles/Services/Styles/StyleService.Queries.cs
@@ -1,0 +1,56 @@
+﻿// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib
+// Licensed under the MIT License.
+// See License.txt in the project root for license information.
+// ---------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Text;
+using SharpStyles.Models.Queries;
+
+namespace SharpStyles.Services.Styles
+{
+    internal partial class StyleService : IStyleService
+    {
+        public string ToQueryCss(MediaQuery mediaQuery)
+        {
+            var stringBuilder = new StringBuilder();
+            stringBuilder.AppendLine();
+            stringBuilder.Append("@media ");
+
+            if (mediaQuery.Not)
+                stringBuilder.Append("not ");
+
+            if (mediaQuery.Only)
+                stringBuilder.Append("only ");
+
+            if (string.IsNullOrWhiteSpace(mediaQuery.MediaType) is false)
+                stringBuilder.Append(mediaQuery.MediaType + " ");
+
+            var conditions = new List<string>();
+
+            if (mediaQuery.MinWidth.HasValue)
+                conditions.Add($"(min-width: {mediaQuery.MinWidth}px)");
+
+            if (mediaQuery.MaxWidth.HasValue)
+                conditions.Add($"(max-width: {mediaQuery.MaxWidth}px)");
+
+            if (string.IsNullOrWhiteSpace(mediaQuery.CustomFeature) is false)
+                conditions.Add($"({mediaQuery.CustomFeature.Trim('(').Trim(')')})");
+
+            if (conditions.Count > 0)
+            {
+                if (!string.IsNullOrWhiteSpace(mediaQuery.MediaType) || mediaQuery.Not || mediaQuery.Only)
+                    stringBuilder.Append("and ");
+
+                stringBuilder.Append(string.Join(" and ", conditions));
+            }
+
+            stringBuilder.AppendLine(" {");
+            stringBuilder.AppendLine(ToCss(mediaQuery.Styles) ?? string.Empty);
+            stringBuilder.AppendLine("}");
+
+            return stringBuilder.ToString();
+        }
+    }
+}

--- a/SharpStyles/Services/Styles/StyleService.Queries.cs
+++ b/SharpStyles/Services/Styles/StyleService.Queries.cs
@@ -47,7 +47,7 @@ namespace SharpStyles.Services.Styles
             }
 
             stringBuilder.AppendLine(" {");
-            stringBuilder.AppendLine(ToCss(mediaQuery.Styles) ?? string.Empty);
+            stringBuilder.AppendLine(ToStyleCss(mediaQuery.Styles) ?? string.Empty);
             stringBuilder.AppendLine("}");
 
             return stringBuilder.ToString();

--- a/SharpStyles/Services/Styles/StyleService.Styles.cs
+++ b/SharpStyles/Services/Styles/StyleService.Styles.cs
@@ -15,7 +15,7 @@ namespace SharpStyles.Services.Styles
 {
     internal partial class StyleService : IStyleService
     {
-        public string ToCss(SharpStyle sharpStyle)
+        public string ToStyleCss(SharpStyle sharpStyle)
         {
             var stringBuilder = new StringBuilder();
             stringBuilder.AppendLine();

--- a/SharpStyles/Services/Styles/StyleService.Styles.cs
+++ b/SharpStyles/Services/Styles/StyleService.Styles.cs
@@ -32,8 +32,8 @@ namespace SharpStyles.Services.Styles
                             property.PropertyType.GetGenericArguments()[0] == typeof(MediaQuery))
                 {
                     AppendMediaQueryBlock(sharpStyle, property, stringBuilder);
+                    continue;
                 }
-
             }
 
             return stringBuilder.ToString();

--- a/SharpStyles/Services/Styles/StyleService.Styles.cs
+++ b/SharpStyles/Services/Styles/StyleService.Styles.cs
@@ -1,0 +1,42 @@
+﻿// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib
+// Licensed under the MIT License.
+// See License.txt in the project root for license information.
+// ---------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using SharpStyles.Models;
+using SharpStyles.Models.Queries;
+
+namespace SharpStyles.Services.Styles
+{
+    internal partial class StyleService : IStyleService
+    {
+        public string ToCss(SharpStyle sharpStyle)
+        {
+            var stringBuilder = new StringBuilder();
+            stringBuilder.AppendLine();
+
+            foreach (PropertyInfo property in sharpStyle.GetType().GetProperties())
+            {
+                if (property.PropertyType.IsEquivalentTo(typeof(SharpStyle)))
+                {
+                    AppendStyleBlock(sharpStyle, property, stringBuilder);
+                    continue;
+                }
+
+                if (property.PropertyType.IsGenericType &&
+                        property.PropertyType.GetGenericTypeDefinition() == typeof(List<>) &&
+                            property.PropertyType.GetGenericArguments()[0] == typeof(MediaQuery))
+                {
+                    AppendMediaQueryBlock(sharpStyle, property, stringBuilder);
+                }
+
+            }
+
+            return stringBuilder.ToString();
+        }
+    }
+}

--- a/SharpStyles/Services/Styles/StyleService.Styles.cs
+++ b/SharpStyles/Services/Styles/StyleService.Styles.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
 using SharpStyles.Models;
+using SharpStyles.Models.Keyframes;
 using SharpStyles.Models.Queries;
 
 namespace SharpStyles.Services.Styles
@@ -33,6 +34,13 @@ namespace SharpStyles.Services.Styles
                 {
                     AppendMediaQueryBlock(sharpStyle, property, stringBuilder);
                     continue;
+                }
+
+                if (property.PropertyType.IsGenericType &&
+                        property.PropertyType.GetGenericTypeDefinition() == typeof(List<>) &&
+                            property.PropertyType.GetGenericArguments()[0] == typeof(SharpKeyframes))
+                {
+                    AppendKeyframesBlock(sharpStyle, property, stringBuilder);
                 }
             }
 

--- a/SharpStyles/Services/Styles/StyleService.cs
+++ b/SharpStyles/Services/Styles/StyleService.cs
@@ -11,6 +11,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using SharpStyles.Models;
 using SharpStyles.Models.Attributes;
+using SharpStyles.Models.Keyframes;
 using SharpStyles.Models.Queries;
 
 namespace SharpStyles.Services.Styles
@@ -95,5 +96,22 @@ namespace SharpStyles.Services.Styles
             }
         }
 
+        private void AppendKeyframesBlock(
+            SharpStyle sharpStyle,
+            PropertyInfo property,
+            StringBuilder stringBuilder)
+        {
+            IEnumerable<SharpKeyframes> sharpKeyframes =
+                property.GetValue(sharpStyle)
+                    as IEnumerable<SharpKeyframes>;
+
+            if (sharpKeyframes == null)
+                return;
+
+            foreach (var keyframes in sharpKeyframes)
+            {
+                stringBuilder.AppendLine(ToKeyframesCss(keyframes));
+            }
+        }
     }
 }

--- a/SharpStyles/Services/Styles/StyleService.cs
+++ b/SharpStyles/Services/Styles/StyleService.cs
@@ -1,0 +1,22 @@
+﻿// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib
+// Licensed under the MIT License.
+// See License.txt in the project root for license information.
+// ---------------------------------------------------------------
+
+using System.Text.RegularExpressions;
+using SharpStyles.Models;
+
+namespace SharpStyles.Services.Styles
+{
+    internal partial class StyleService : IStyleService
+    {
+        private static readonly Regex PascalToKebabRegex =
+            new Regex("([a-z,0-9](?=[A-Z])|[A-Z](?=[A-Z][a-z]))");
+
+        public string ToCss(SharpStyle sharpStyle)
+        {
+            return string.Empty;
+        }
+    }
+}

--- a/SharpStyles/Services/Styles/StyleService.cs
+++ b/SharpStyles/Services/Styles/StyleService.cs
@@ -29,11 +29,12 @@ namespace SharpStyles.Services.Styles
             string prefix = null;
             string selectorCss = null;
 
-            foreach (var attribute in property.CustomAttributes)
+            foreach (CustomAttributeData attribute in property.CustomAttributes)
             {
                 if (attribute.NamedArguments.Any())
                 {
-                    selectorCss = attribute.NamedArguments[0].TypedValue.Value.ToString();
+                    selectorCss =
+                        attribute.NamedArguments[0].TypedValue.Value.ToString();
                 }
                 else
                 {
@@ -51,9 +52,7 @@ namespace SharpStyles.Services.Styles
             stringBuilder.AppendLine();
             stringBuilder.Append($"{prefix}{selectorCss} {{");
             stringBuilder.AppendLine();
-
             AppendInnerStyles(sharpStyle, property, stringBuilder);
-
             stringBuilder.Append("}");
             stringBuilder.AppendLine();
         }
@@ -63,8 +62,8 @@ namespace SharpStyles.Services.Styles
             PropertyInfo property,
             StringBuilder stringBuilder)
         {
-            var styleValue = property.GetValue(sharpStyle);
-            if (styleValue == null) return;
+            object styleValue = property.GetValue(sharpStyle);
+            if (styleValue is null) return;
 
             foreach (PropertyInfo innerProperty in property.PropertyType.GetProperties())
             {
@@ -87,12 +86,13 @@ namespace SharpStyles.Services.Styles
                 property.GetValue(sharpStyle)
                     as IEnumerable<MediaQuery>;
 
-            if (mediaQueries == null)
+            if (mediaQueries is null)
                 return;
 
-            foreach (var mediaQuery in mediaQueries)
+            foreach (MediaQuery mediaQuery in mediaQueries)
             {
-                stringBuilder.AppendLine(ToQueryCss(mediaQuery));
+                stringBuilder.AppendLine(
+                    value: ToQueryCss(mediaQuery));
             }
         }
 
@@ -108,9 +108,10 @@ namespace SharpStyles.Services.Styles
             if (sharpKeyframes == null)
                 return;
 
-            foreach (var keyframes in sharpKeyframes)
+            foreach (SharpKeyframes keyframes in sharpKeyframes)
             {
-                stringBuilder.AppendLine(ToKeyframesCss(keyframes));
+                stringBuilder.AppendLine(
+                    value: ToKeyframesCss(keyframes));
             }
         }
     }

--- a/SharpStyles/Services/Styles/StyleService.cs
+++ b/SharpStyles/Services/Styles/StyleService.cs
@@ -4,12 +4,14 @@
 // See License.txt in the project root for license information.
 // ---------------------------------------------------------------
 
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 using SharpStyles.Models;
 using SharpStyles.Models.Attributes;
+using SharpStyles.Models.Queries;
 
 namespace SharpStyles.Services.Styles
 {
@@ -17,22 +19,6 @@ namespace SharpStyles.Services.Styles
     {
         private static readonly Regex PascalToKebabRegex =
             new Regex("([a-z,0-9](?=[A-Z])|[A-Z](?=[A-Z][a-z]))");
-
-        public string ToCss(SharpStyle sharpStyle)
-        {
-            var stringBuilder = new StringBuilder();
-            stringBuilder.AppendLine();
-
-            foreach (PropertyInfo property in sharpStyle.GetType().GetProperties())
-            {
-                if (property.PropertyType.IsEquivalentTo(typeof(SharpStyle)))
-                {
-                    AppendStyleBlock(sharpStyle, property, stringBuilder);
-                }
-            }
-
-            return stringBuilder.ToString();
-        }
 
         private static void AppendStyleBlock(
             SharpStyle sharpStyle,
@@ -90,5 +76,24 @@ namespace SharpStyles.Services.Styles
                 }
             }
         }
+
+        private void AppendMediaQueryBlock(
+            SharpStyle sharpStyle,
+            PropertyInfo property,
+            StringBuilder stringBuilder)
+        {
+            IEnumerable<MediaQuery> mediaQueries =
+                property.GetValue(sharpStyle)
+                    as IEnumerable<MediaQuery>;
+
+            if (mediaQueries == null)
+                return;
+
+            foreach (var mediaQuery in mediaQueries)
+            {
+                stringBuilder.AppendLine(ToQueryCss(mediaQuery));
+            }
+        }
+
     }
 }

--- a/SharpStyles/SharpStyles.csproj
+++ b/SharpStyles/SharpStyles.csproj
@@ -43,4 +43,9 @@
 	  </None>
 	</ItemGroup>
 
+	<ItemGroup>
+		<InternalsVisibleTo Include="SharpStyles.Tests.Unit" />
+		<InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+	</ItemGroup>
+
 </Project>


### PR DESCRIPTION
- Redeay for review.
- Pending #24 

**This PR introduces a unified way to convert all styles, including `MediaQuery` and `Keyframes`, at once.**

## What's New?

The `.ToCss()` method is now **deprecated** in favor of more explicit and extensible extension methods:

- `ToStyleCss()` — Converts all styles, including `MediaQuery` and `Keyframes`, to a full CSS string.
- `ToQueryCss()` — Converts only the `MediaQuery` entries to a CSS string.
- `ToKeyframesCss()` — Converts only the `Keyframes` definitions to a CSS string.
