### PR TITLE
MINOR FIX: Converting of Hex Values into CSS Values Are Wrong

### DIFF
--- a/SharpStyles.Tests.Unit/Services/Styles/StyleServiceTests.Logic.cs
+++ b/SharpStyles.Tests.Unit/Services/Styles/StyleServiceTests.Logic.cs
@@ -294,5 +294,65 @@ my-element {{
             // then
             actualStyle.Should().BeEquivalentTo(expectedStyle);
         }
+
+        [Theory]
+        [InlineData("#ff0000")]
+        [InlineData("#00FF00")]
+        [InlineData("#0000fF")]
+        [InlineData("#123456")]
+        public void ShouldSerializeSharpStyleToCssRulesWithUppercasedAndLowercasedHexColors(string hexColor)
+        {
+            // given
+            var testStyle = new TestStyle
+            {
+                MyElement = new SharpStyle
+                {
+                    BackgroundColor = hexColor
+                },
+
+                MyId = new SharpStyle
+                {
+                    BackgroundColor = hexColor
+                },
+
+                MyClass = new SharpStyle
+                {
+                    BackgroundColor = hexColor
+                },
+
+                MyDeep = new SharpStyle
+                {
+                    BackgroundColor = hexColor
+                }
+            };
+
+            string expectedStyle = @$"
+
+my-element {{
+	background-color: {hexColor};
+}}
+
+#my-id {{
+	background-color: {hexColor};
+}}
+
+.my-class {{
+	background-color: {hexColor};
+}}
+
+::deep my-deep {{
+	background-color: {hexColor};
+}}
+";
+
+            // when
+            IStyleService styleService = new StyleService();
+
+            string actualStyle = styleService.ToStyleCss(
+                sharpStyle: testStyle);
+
+            // then
+            actualStyle.Should().BeEquivalentTo(expectedStyle);
+        }
     }
 }

--- a/SharpStyles/Services/Styles/StyleService.cs
+++ b/SharpStyles/Services/Styles/StyleService.cs
@@ -70,8 +70,9 @@ namespace SharpStyles.Services.Styles
                 var value = innerProperty.GetValue(styleValue);
                 if (value != null)
                 {
-                    string raw = $"\t{innerProperty.Name}: {value};";
-                    stringBuilder.Append(PascalToKebabRegex.Replace(raw, "$1-").ToLower());
+                    string formattedName = PascalToKebabRegex.Replace(innerProperty.Name, "$1-").ToLower();
+                    string raw = $"\t{formattedName}: {value};";
+                    stringBuilder.Append(raw);
                     stringBuilder.AppendLine();
                 }
             }


### PR DESCRIPTION
- Closes #6 
## Before:

writing uppercased colors or any uppercased values causes extra split with `-`:

```cs
MyId = new SharpStyle
{
    BackgroundColor = "#01FF00"
},
```

Generates:

```css
#my-id {
	background-color: #00-ff00;
}
```
## After:

```cs
MyId = new SharpStyle
{
    BackgroundColor = "#01FF00"
},
```

Generates:

```css
#my-id {
	background-color: #00FF00;
}
```