### PR TITLE
MINOR DATA: Add Object Fit Property

### DIFF
--- a/SharpStyles/Models/SharpStyle.cs
+++ b/SharpStyles/Models/SharpStyle.cs
@@ -589,6 +589,11 @@ namespace SharpStyles.Models
         public string MinWidth { get; set; }
 
         /// <summary>
+        /// Specifies how the content of a replaced element (e.g., image or video) should be resized to fit its container.
+        /// </summary>
+        public string ObjectFit { get; set; }
+
+        /// <summary>
         /// Specifies the transparency of an element.
         /// </summary>
         public string Opacity { get; set; }


### PR DESCRIPTION
* The object-fit [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS) property sets how the content of a [replaced element](https://developer.mozilla.org/en-US/docs/Glossary/Replaced_elements), such as an [<img>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img) or [<video>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/video), should be resized to fit its container.
* Closes #31 
* Documentation reference: https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit...
![image](https://github.com/user-attachments/assets/9bf98d78-11ac-4676-b137-4e3a8bdc2025)
